### PR TITLE
make it appear only as splashscreen

### DIFF
--- a/a2n.kuro/metadata.json
+++ b/a2n.kuro/metadata.json
@@ -1,5 +1,5 @@
 {
-    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPackageStructure": "Plasma/LookAndFeel/Splash",
     "KPlugin": {
         "Authors": [
             {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/bouteillerAlan/archupdate/blob/main/CONTRIBUTING.md.

For code changes:
1. Include description (and screenshot if needed) for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that all the old features is not broken.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that thi project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Created my own splashscreen earlier and noticed some of the existing ones (for plasma6) appear both in splashscreens but also in the Global Theme main category